### PR TITLE
Remove always-false condition from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ const service = sdk.service(function(err, service) {
     // Assume that data is retrieved and stored in "entity" variable
 
     // After entity is retrieved, check to see if it exists
-    if (typeof entity === 'undefined' || entity === null || entity === {}) {
+    if (typeof entity === 'undefined' || entity === null) {
       return complete("The entity could not be found").notFound().next();
     } else  {
       // return the entity


### PR DESCRIPTION
Comparing objects using strict equality (===) compares references rather than contents, and will always return false unless comparing an object to itself. Since this is comparing the object `entity` to a new empty object, it will by definition always return false.