### PR TITLE
BACK-1991 Apply new branding and namespacing to sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ The FlexData framework can be accessed via the sdk's `data` property.
 const flexData = flex.data;
 ```
 
-### Registering ServiceObjects
+### Registering serviceObjects
 
-Once you initialize the FlexData framework, you define your entites by defining ServiceObjects, and then wire up data access event handlers to those ServiceObjects.  To register a ServiceObject, use the `serviceObject` method of the `data` framework:
+Once you initialize the FlexData framework, you define your entites by defining ServiceObjects, and then wire up data access event handlers to those ServiceObjects.  To register a ServiceObject, use the `serviceObject` method of the `data` object:
 
 ```
 // To register the 'widgets' ServiceObject:
@@ -76,9 +76,9 @@ widgets.onGetAll(callbackFunction);
 
 ### Data Handler Functions
 
-The data events take a handler functions, which takes three arguments:  `request`, `complete`, and `modules`.  `request` represents the request made to Kinvey, and `complete` is a completion handler for completing the data request.  The modules `modules` argument is an object containing several libraries for accessing Kinvey functionality via your service (for more information, see the section on [modules](#modules)).
+The data events take a handler function, which takes three arguments:  `request`, `complete`, and `modules`.  `request` represents the request made to Kinvey, and `complete` is a completion handler for completing the data request.  The `modules` argument is an object containing several libraries for accessing Kinvey functionality via your service (for more information, see the section on [modules](#modules)).
 
-#### request object
+#### request Object
 
 The request object contains the following properties
 
@@ -91,7 +91,7 @@ The request object contains the following properties
 | body | the HTTP body |
 | query | the query object |
 
-#### Completion Handler
+#### completion Handler
 
 The completion handlers object follows a builder pattern for creating the handler's response.  The pattern for the completion handler is `complete(<entity>).<status>.<done|next>`
 
@@ -116,7 +116,7 @@ complete([{"foo":"bar"}, {"abc":"123}]);
 complete("Record 123 was not found");
 ```
 
-##### status functions
+##### Status Functions
 
 Status functions set the valid status codes for a Data Link Connector.  The status function also sets the body to a Kinvey-formatted error, and uses the value passed into the `complete` function as the debug property, if it is present.
 
@@ -145,7 +145,7 @@ complete(myRecord).created();
 complete("The given entity wasn't found").notFound();
 ```
 
-##### End processing
+##### End Processing
 
 Once the status is set, you can end the processing of the handler request with either `done` or `next`.  Most requests should normally end with `next`, which will continue the Kinvey request pipeline.  `done` will return the response that was set in the completion handler, and end request processing without executing any further functions.
 
@@ -210,7 +210,7 @@ const functions = flex.functions;
 
 ### Registering FlexFunction Handlers
 
-In order to register a FlexFunction handler, you define that handler and give it a name by using the `register` method of the `functions` framework:
+In order to register a FlexFunction handler, you define that handler and give it a name by using the `register` method of the `functions` object:
 
 ```
 // To register the 'someEventHandlerName' handler:
@@ -221,9 +221,9 @@ In the console, when you define hooks or endpoints, you will be presented your l
 
 ### Handler Functions
 
-Like the Data handlers, FlexFunctions take a handler functions with three arguments:  `request`, `complete`, and `modules`.  `request` represents the handler request's current state, and `complete` is a completion handler for completing the function.  The modules `modules` argument is an object containing several libraries for accessing Kinvey functionality via your service (for more information, see the section on [modules](#modules)).
+Like the Data handlers, FlexFunctions take a handler functions with three arguments:  `request`, `complete`, and `modules`.  `request` represents the handler request's current state, and `complete` is a completion handler for completing the function.  The `modules` argument is an object containing several libraries for accessing Kinvey functionality via your service (for more information, see the section on [modules](#modules)).
 
-#### request object
+#### request Object
 
 The request object contains the following properties:
 
@@ -236,7 +236,7 @@ The request object contains the following properties:
 | body | the HTTP body |
 | query | the query object |
 
-#### Completion Handler
+#### completion Handler
 
 The completion handlers object follows a builder pattern for creating the FlexFunctions' response.  The pattern for the completion handler is `complete(<entity>).<status>.<done|next>`
 
@@ -269,7 +269,7 @@ complete([{"foo":"bar"}, {"abc":"123}]);
 complete("Record 123 was not found");
 ```
 
-##### status functions
+##### Status Functions
 
 Status functions set the valid status codes for the request.  The status function also sets the body to a Kinvey-formatted error, and uses the value passed into the `complete` function as the debug property, if it is present.
 
@@ -298,7 +298,7 @@ complete(myRecord).created();
 complete("The given entity wasn't found").notFound();
 ```
 
-##### End processing
+##### End Processing
 
 Once the status is set, you can end the processing of the handler request with either `done` or `next`.  Most requests should normally end with `next`, which will continue the Kinvey request pipeline.  `done` will return the response that was set in the handler, and end request processing without executing any further part of the kinvey request pipeline.
 
@@ -341,7 +341,7 @@ sdk.service(function(err, flex) {
 
 You can include both FlexData and FlexFunctions' handlers in the same flex service, but it is recommended to separate the two.
 
-## [Executing a long-running script](#long-running-scripts)
+## [Executing a Long-running Script](#long-running-scripts)
 
 Because the services are persisted, you can execute long running tasks that run in the background.  However, all requests still need to be completed in less than 60 seconds.  
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,23 @@
-# Kinvey Backend SDK (beta)
+# Kinvey Flex SDK (beta)
 
-This is the SDK for Backend code execution for kinvey-hosted Data Link Connectors and Logic tasks. The module provides a framework for building kinvey-backed Data Link Connectors easily.
-
-This module provides an easy way to connect to a Kinvey Business Logic (BL) instance running on docker. It is up to the user to download, configure and start the docker image itself before running code using this module. Two [utility](#Utilities) functions are provided to automate setting up the docker image.
+This is the SDK for code execution of Flex Microservices. The module provides a framework for building kinvey-backed FlexData and FlexFunctions.
 
 ## [Installation](#installation)
 
 To install this project, add it to your `package.json` file and install it via `npm`
 ```
-npm install kinvey-backend-sdk
+npm install kinvey-flex-sdk
 ```
 
 To use this module, require it in your project and
 ```
-const sdk = require('kinvey-backend-sdk');
+const sdk = require('kinvey-flex-sdk');
 ```
 
 You then must initialize the sdk to retrieve a reference to the backend service:
 
 ```
-const service = sdk.service((err, service) => {
+service((err, flex) => {
   // code goes here
 };
 ```
@@ -28,28 +26,28 @@ const service = sdk.service((err, service) => {
 When running locally, you can specify a host and port to listen on by passing an options object with an optional host and port.  If no host/port is specified, localhost:10001 will be used:
 
 ```
-const service = sdk.service({ host: 'somehost', port: 7777 }, (err, service) => {
+sdk.service({ host: 'somehost', port: 7777 }, (err, flex) => {
   // code goes here
 });
 ```
 
 To run your code locally, execute `node .` in the root of your project.  Routes conform to the Kinvey Data Link specification.  
 
-## [DataLink framework](#datalink-framework)
+## [FlexData](#flex-data)
 
-The DataLink framework can be accessed via the sdk's `dataLink` property.
+The FlexData framework can be accessed via the sdk's `data` property.
 
 ```
-const dataLink = service.dataLink;
+const flexData = flex.data;
 ```
 
 ### Registering ServiceObjects
 
-Once you initialize the DataLink framework, you define your entites by defining ServiceObjects, and then wire up data access event handlers to those ServiceObjects.  To register a ServiceObject, use the `serviceObject` method of the `dataLink` framework:
+Once you initialize the FlexData framework, you define your entites by defining ServiceObjects, and then wire up data access event handlers to those ServiceObjects.  To register a ServiceObject, use the `serviceObject` method of the `data` framework:
 
 ```
 // To register the 'widgets' ServiceObject:
-const widgets = service.dataLink.serviceObject('widgets');
+const widgets = flex.data.serviceObject('widgets');
 ```
 
 ### Data Events
@@ -78,7 +76,7 @@ widgets.onGetAll(callbackFunction);
 
 ### Data Handler Functions
 
-The data events take a handler funciton, which takes three arguments:  `request`, `complete`, and `modules`.  `request` represents the request made to Kinvey, and `complete` is a completion handler for completing the data request.  The modules `modules` argument is an object containing several libraries for accessing Kinvey functionality via your service (for more information, see the section on [modules](#modules)).  
+The data events take a handler functions, which takes three arguments:  `request`, `complete`, and `modules`.  `request` represents the request made to Kinvey, and `complete` is a completion handler for completing the data request.  The modules `modules` argument is an object containing several libraries for accessing Kinvey functionality via your service (for more information, see the section on [modules](#modules)).
 
 #### request object
 
@@ -95,7 +93,7 @@ The request object contains the following properties
 
 #### Completion Handler
 
-The completion handlers object follows a builder pattern for creating the datalink's response.  The pattern for the completion handler is `complete(<entity>).<status>.<done|next>`
+The completion handlers object follows a builder pattern for creating the handler's response.  The pattern for the completion handler is `complete(<entity>).<status>.<done|next>`
 
 For example, a sample completion handler is:
 
@@ -149,7 +147,7 @@ complete("The given entity wasn't found").notFound();
 
 ##### End processing
 
-Once the status is set, you can end the processing of the dataLink request with either `done` or `next`.  Most requests should normally end with `next`, which will continue the Kinvey request pipeline with Business Logic.  `done` will return the response that was set in the DataLink, and end request processing without executing any further business logic.
+Once the status is set, you can end the processing of the handler request with either `done` or `next`.  Most requests should normally end with `next`, which will continue the Kinvey request pipeline.  `done` will return the response that was set in the completion handler, and end request processing without executing any further functions.
 
 ```
 // This will continue the request chain
@@ -164,9 +162,9 @@ complete(myEntity).ok().done();
 The following is an example
 
 ```
-const sdk = require('kinvey-backend-sdk');
-const service = sdk.service(function(err, service) {
-  const dataLink = service.dataLink;   // gets the datalink object from the service
+const sdk = require('kinvey-flex-sdk');
+sdk.service(function(err, flex) {
+  const data = flex.data;   // gets the FlexData object from the service
 
   function getRecordById(request, complete, modules) {
     let entityId = request.entityId;
@@ -185,7 +183,7 @@ const service = sdk.service(function(err, service) {
   }
 
   // set the serviceObject
-  const widgets = dataLink.serviceObject('widgets');
+  const widgets = data.serviceObject('widgets');
 
   // wire up the event that we want to process
   widgets.onGetById(getRecordById);
@@ -202,28 +200,28 @@ const service = sdk.service(function(err, service) {
 };
 ```
 
-## [Business Logic framework](#business-logic-framework)
+## [FlexFunctions](#flex-functions)
 
-The Business Logic framework can be accessed via the sdk's `businessLogic` property.
-
-```
-const dataLink = sdk.businessLogic;
-```
-
-### Registering Business Logic Handlers
-
-In order to register a business logic handler, you define that handler and give it a name by using the `register` method of the `businessLogic` framework:
+The FlexFunctions framework is used to execute functions invoked by `hooks` or `endpoints`.  It can be accessed via the sdk's `functions` property.
 
 ```
-// To register the '' handler:
-const widgets = sdk.businessLogic.register('someEventHanlerName', eventHandlerCallbackFunction);
+const functions = flex.functions;
 ```
 
-In the console, when you define business logic, you will be presented your list of event handlers to tie to a collection hook or custom endpoint.
+### Registering FlexFunction Handlers
 
-### Business Logic Handler Functions
+In order to register a FlexFunction handler, you define that handler and give it a name by using the `register` method of the `functions` framework:
 
-Like the DataLink handlers, business logic events take a handler funciton, which takes three arguments:  `request`, `complete`, and `modules`.  `request` represents the request made to Kinvey, and `complete` is a completion handler for completing the business logic.  The modules `modules` argument is an object containing several libraries for accessing Kinvey functionality via your service (for more information, see the section on [modules](#modules)).  
+```
+// To register the 'someEventHandlerName' handler:
+const widgets = flex.functions.register('someEventHandlerName', eventHandlerCallbackFunction);
+```
+
+In the console, when you define hooks or endpoints, you will be presented your list of event handlers to tie to a collection hook or endpoint.
+
+### Handler Functions
+
+Like the Data handlers, FlexFunctions take a handler functions with three arguments:  `request`, `complete`, and `modules`.  `request` represents the handler request's current state, and `complete` is a completion handler for completing the function.  The modules `modules` argument is an object containing several libraries for accessing Kinvey functionality via your service (for more information, see the section on [modules](#modules)).
 
 #### request object
 
@@ -240,7 +238,7 @@ The request object contains the following properties:
 
 #### Completion Handler
 
-The completion handlers object follows a builder pattern for creating the business logic's response.  The pattern for the completion handler is `complete(<entity>).<status>.<done|next>`
+The completion handlers object follows a builder pattern for creating the FlexFunctions' response.  The pattern for the completion handler is `complete(<entity>).<status>.<done|next>`
 
 For example, a sample completion handler is:
 
@@ -302,7 +300,7 @@ complete("The given entity wasn't found").notFound();
 
 ##### End processing
 
-Once the status is set, you can end the processing of the business logic request with either `done` or `next`.  Most requests should normally end with `next`, which will continue the Kinvey request pipeline with Business Logic.  `done` will return the response that was set in the handler, and end request processing without executing any further part of the kinvey request pipeline.
+Once the status is set, you can end the processing of the handler request with either `done` or `next`.  Most requests should normally end with `next`, which will continue the Kinvey request pipeline.  `done` will return the response that was set in the handler, and end request processing without executing any further part of the kinvey request pipeline.
 
 ```
 // This will continue the request chain
@@ -317,14 +315,14 @@ complete(myEntity).ok().done();
 The following is an example
 
 ```
-const sdk = require('kinvey-backend-sdk');
+const sdk = require('kinvey-flex-sdk');
 const request = require('request'); // assumes that the request module was added to package.json
-const service = sdk.service(function(err, service) {
+sdk.service(function(err, flex) {
   
-  const bl = service.businessLogic;   // gets the businessLogic object from the service
+  const flexFunctions = flex.functions;   // gets the FlexFunctions object from the service
 
   function getRedLineSchedule(req, complete, modules) {
-    requset.get('http://developer.mbta.com/Data/Red.json', (err, response, body) => {
+    request.get('http://developer.mbta.com/Data/Red.json', (err, response, body) => {
       // if error, return an error
       if (err) {
         return complete("Could not complete request").runtimeError().done();
@@ -337,11 +335,11 @@ const service = sdk.service(function(err, service) {
    }
 
   // set the handler
-  bl.register('getRedLineData', getRedLineSchedule);
+  flexFunctions.register('getRedLineData', getRedLineSchedule);
 };
 ```
 
-You can include both dataLink and business logic handlers in the same flex service, but it is recommended to separate the two.
+You can include both FlexData and FlexFunctions' handlers in the same flex service, but it is recommended to separate the two.
 
 ## [Executing a long-running script](#long-running-scripts)
 
@@ -352,11 +350,11 @@ To accomplish this, you can execute a function asynchronously using one of the `
 For example:  
 
 ```
-const sdk = require('kinvey-backend-sdk');
+const sdk = require('kinvey-flex-sdk');
 const request = require('request'); // assumes that the request module was added to package.json
-const service = sdk.service(function(err, service) {
+sdk.service(function(err, flex) {
   
-  const bl = service.businessLogic;   // gets the businessLogic object from the service
+  const flexFunctions = flex.functions;   // gets the FlexFunctions object from the service
 
     function calcSomeData() {
         // do something
@@ -393,11 +391,11 @@ const service = sdk.service(function(err, service) {
     // Since the calc and post data function may take a long time, execute it asynchronously
     setImmediate(calcAndPostData);  
     
-    // Immediately complete the business logic script.  The response will be returned to the caller, and calcAndPostData will execute in the background.  
+    // Immediately complete the handler function.  The response will be returned to the caller, and calcAndPostData will execute in the background.
     complete().accepted().done();
     
   // set the handler to point to the initiateCalcAndPost header
-  bl.register('getRedLineData', initiateCalcAndPost);
+  flexFunctions.register('getRedLineData', initiateCalcAndPost);
 };
 ```
 
@@ -406,7 +404,7 @@ In the above example, the handler receives a request and executes the `initiateC
 
 ## [Modules](#modules)
 
-Modules are a set of libraries inteded for accessing Kinvey-specific functionality.  The optional `modules` argument is passed as the third argument to all handler functions.  For example:
+Modules are a set of libraries intended for accessing Kinvey-specific functionality.  The optional `modules` argument is passed as the third argument to all handler functions.  For example:
 
 ```
 // data handler
@@ -861,13 +859,13 @@ For example, to send a broadcast with payloads:
 
 ```javascript
 const iOSAps = { alert: "You have a new message", badge: 2, sound: "notification.wav" }
-const iOSExtras = {from: "Kinvey", subject: "Welcome to Business Logic"}
+const iOSExtras = {from: "Kinvey", subject: "Welcome to Flex Services!"}
 const androidPayload = {message: "You have a new Message", from: "Kinvey", subject: "Welcome to BL" }
 const push = modules.push;
 push.broadcastPayload(iOSAps, iOSExtras, androidPayload, callback);
 ```
 
-Push calls are asynchronous in nature.  They can be invoked without a callback, but are not guaranteed to complete before continuing to the next statement.  However, once invoked they will complete the sending of the push messages, even if the business logic is terminated via a completion handler.  
+Push calls are asynchronous in nature.  They can be invoked without a callback, but are not guaranteed to complete before continuing to the next statement.  However, once invoked they will complete the sending of the push messages, even if the handler function is terminated via a completion handler.
 
 *Note:* The email module is currently only available for services running on the Kinvey Microservices Runtime, and is not available externally or for local testing.  
 
@@ -1227,4 +1225,4 @@ The `X-Kinvey-Original-Request-Headers` object can contain any number of custom 
 | `x-kinvey-api-version` | The API version to use (number).  Note this is important for the `dataStore` module. | 
 | `authorization` | The authorization string (either Basic or Kinvey auth) for accessing Kinvey's REST service. | 
 | `x-kinvey-client-app-version` | The Client App Version string |
-| `x-kinvey-custom-request-properties` | A JSON-stringified The custom request properties.  |  
+| `x-kinvey-custom-request-properties` | A JSON-stringified The custom request properties.  |

--- a/index.js
+++ b/index.js
@@ -10,4 +10,4 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-module.exports = require('./lib/sdk');
+module.exports = require('./lib/flex');

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -41,7 +41,7 @@ class Flex {
 
     // TODO Remove legacy taskType values
     const taskReceivedCallback = (task, completionCallback) => {
-      if (task.taskType === 'data' || task.taskType === 'dataLink' ) {
+      if (task.taskType === 'data' || task.taskType === 'dataLink') {
         return this.data.process(task, this.moduleGenerator.generate(task), completionCallback);
       } else if (task.taskType === 'serviceDiscovery') {
         task.discoveryObjects = {

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -39,8 +39,9 @@ class Flex {
     this.logger = logger;
     this.moduleGenerator = moduleGenerator;
 
+    // TODO Remove legacy taskType values
     const taskReceivedCallback = (task, completionCallback) => {
-      if (task.taskType === 'data') {
+      if (task.taskType === 'data' || task.taskType === 'dataLink' ) {
         return this.data.process(task, this.moduleGenerator.generate(task), completionCallback);
       } else if (task.taskType === 'serviceDiscovery') {
         task.discoveryObjects = {
@@ -52,7 +53,7 @@ class Flex {
           }
         };
         return completionCallback(null, task);
-      } else if (task.taskType === 'functions') {
+      } else if (task.taskType === 'functions' || task.taskType === 'businessLogic') {
         return this.functions.process(task, this.moduleGenerator.generate(task), completionCallback);
       }
 

--- a/lib/flex.js
+++ b/lib/flex.js
@@ -14,12 +14,12 @@
 
 const isNil = require('lodash.isnil');
 const receiver = require('kinvey-code-task-runner');
-const dataLink = require('./service/dataLink');
-const businessLogic = require('./service/businessLogic');
+const data = require('./service/data');
+const functions = require('./service/functions');
 const moduleGenerator = require('./service/moduleGenerator');
 const logger = require('./service/logger');
 
-class Service {
+class Flex {
   constructor(options, callback) {
     if (!callback && typeof options === 'function') {
       callback = options;
@@ -34,26 +34,26 @@ class Service {
       delete options.port;
     }
 
-    this.dataLink = dataLink;
-    this.businessLogic = businessLogic;
+    this.data = data;
+    this.functions = functions;
     this.logger = logger;
     this.moduleGenerator = moduleGenerator;
 
     const taskReceivedCallback = (task, completionCallback) => {
-      if (task.taskType === 'dataLink') {
-        return this.dataLink.process(task, this.moduleGenerator.generate(task), completionCallback);
+      if (task.taskType === 'data') {
+        return this.data.process(task, this.moduleGenerator.generate(task), completionCallback);
       } else if (task.taskType === 'serviceDiscovery') {
         task.discoveryObjects = {
-          dataLink: {
-            serviceObjects: this.dataLink.getServiceObjects()
+          data: {
+            serviceObjects: this.data.getServiceObjects()
           },
-          businessLogic: {
-            handlers: this.businessLogic.getHandlers()
+          functions: {
+            handlers: this.functions.getHandlers()
           }
         };
         return completionCallback(null, task);
-      } else if (task.taskType === 'businessLogic') {
-        return this.businessLogic.process(task, this.moduleGenerator.generate(task), completionCallback);
+      } else if (task.taskType === 'functions') {
+        return this.functions.process(task, this.moduleGenerator.generate(task), completionCallback);
       }
 
       return new Error('Invalid task Type');
@@ -68,15 +68,15 @@ class Service {
   }
 }
 
-function generateService(options, callback) {
+function generateFlexService(options, callback) {
   if (!callback && typeof options === 'function') {
     callback = options;
     options = null;
   }
 
-  return new Service(options, (err, service) => {
+  return new Flex(options, (err, service) => {
     callback(err, service);
   });
 }
 
-exports.service = generateService;
+exports.service = generateFlexService;

--- a/lib/service/data.js
+++ b/lib/service/data.js
@@ -133,7 +133,7 @@ function process(task, modules, callback) {
 
   const serviceObjectToProcess = serviceObject(task.request.serviceObjectName);
   let dataOp = '';
-  const dataLinkCompletionHandler = kinveyCompletionHandler(task, callback);
+  const dataCompletionHandler = kinveyCompletionHandler(task, callback);
 
   try {
     task.request.body = JSON.parse(task.request.body);
@@ -199,7 +199,7 @@ function process(task, modules, callback) {
   }
 
   const operationHandler = serviceObjectToProcess.resolve(dataOp);
-  return operationHandler(task.request, dataLinkCompletionHandler, modules);
+  return operationHandler(task.request, dataCompletionHandler, modules);
 }
 
 function removeServiceObject(serviceObjectToRemove) {

--- a/lib/service/functions.js
+++ b/lib/service/functions.js
@@ -40,7 +40,7 @@ function process(task, modules, callback) {
     return callback(task);
   }
 
-  const businessLogicCompletionHandler = kinveyCompletionHandler(task, callback);
+  const functionCompletionHandler = kinveyCompletionHandler(task, callback);
 
   try {
     task.request.body = JSON.parse(task.request.body);
@@ -54,8 +54,8 @@ function process(task, modules, callback) {
     }
   }
 
-  const logicHandler = resolve(task.taskName);
-  return logicHandler(task.request, businessLogicCompletionHandler, modules);
+  const functionHandler = resolve(task.taskName);
+  return functionHandler(task.request, functionCompletionHandler, modules);
 }
 
 function clearAll() {

--- a/lib/service/kinveyCompletionHandler.js
+++ b/lib/service/kinveyCompletionHandler.js
@@ -91,8 +91,8 @@ function createCompletionHandler(task, callback) {
       runtimeError(debug) {
         result.statusCode = 550;
         result.body = {
-          error: 'DataLinkRuntimeError',
-          description: 'The Datalink had a runtime error.  See debug message for details',
+          error: 'FlexRuntimeError',
+          description: 'The Flex Service had a runtime error.  See debug message for details',
           debug: debug || result.body || {}
         };
         return this;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "kinvey-backend-sdk",
+  "name": "kinvey-flex-sdk",
   "version": "0.5.2",
-  "description": "Backend SDK",
+  "description": "SDK for creating Kinvey Flex Services",
   "engines": {
     "node": "= 6.x.x"
   },
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "Kinvey/backend-sdk"
+    "url": "Kinvey/flex-sdk"
   },
   "license": "Apache-2.0",
   "dependencies": {
@@ -46,9 +46,9 @@
     "pretest": "./node_modules/.bin/eslint lib test",
     "test": "mocha test/lib/modules/* test/lib/*",
     "test-core": "mocha test/lib/*",
-    "test-sdk": "mocha test/lib/sdk.test.js",
-    "test-datalink": "mocha test/lib/dataLink.test.js",
-    "test-businesslogic": "mocha test/lib/businessLogic.test.js",
+    "test-flex": "mocha test/lib/flex.test.js",
+    "test-data": "mocha test/lib/data.test.js",
+    "test-functions": "mocha test/lib/functions.test.js",
     "test-moduleGenerator": "mocha test/lib/moduleGenerator.test.js",
     "test-modules": "mocha test/lib/modules/*",
     "test-backendcontext": "mocha test/lib/modules/backendContext.test.js",

--- a/test/lib/data.test.js
+++ b/test/lib/data.test.js
@@ -12,13 +12,13 @@
  * the License.
  */
 
-const data = require('../../lib/service/dataLink');
+const data = require('../../lib/service/data');
 const should = require('should');
 const serviceObjectName = 'myServiceObject';
 
 function sampleTask() {
   return {
-    taskType: 'dataLink',
+    taskType: 'data',
     method: 'POST',
     endpoint: null,
     request: {
@@ -35,7 +35,7 @@ function sampleTask() {
   };
 }
 
-describe('dataLink', () => {
+describe('data', () => {
   afterEach((done) => {
     data.clearAll();
     return done();
@@ -615,8 +615,8 @@ describe('dataLink', () => {
         should.not.exist(err);
         result.response.statusCode.should.eql(550);
         result.response.body = JSON.parse(result.response.body);
-        result.response.body.error.should.eql('DataLinkRuntimeError');
-        result.response.body.description.should.eql('The Datalink had a runtime error.  See debug message for details');
+        result.response.body.error.should.eql('FlexRuntimeError');
+        result.response.body.description.should.eql('The Flex Service had a runtime error.  See debug message for details');
         result.response.body.debug.should.eql('There was some error in the app!');
         return done();
       });

--- a/test/lib/flex.test.js
+++ b/test/lib/flex.test.js
@@ -21,16 +21,16 @@ const mockTaskReceiver = require('./mocks/mockTaskReceiver.js');
 describe('service creation', () => {
   let sdk = null;
   before((done) => {
-    sdk = proxyquire('../../lib/sdk', { 'kinvey-code-task-runner': mockTaskReceiver });
+    sdk = proxyquire('../../lib/flex', { 'kinvey-code-task-runner': mockTaskReceiver });
     return done();
   });
   it('can create a new service', (done) =>
-    sdk.service((err, service) => {
+    sdk.service((err, flex) => {
       should.not.exist(err);
-      should.exist(service.dataLink);
-      should.exist(service.businessLogic);
-      should.exist(service.moduleGenerator);
-      should.exist(service.logger);
+      should.exist(flex.data);
+      should.exist(flex.functions);
+      should.exist(flex.moduleGenerator);
+      should.exist(flex.logger);
       return done();
     }));
 

--- a/test/lib/functions.test.js
+++ b/test/lib/functions.test.js
@@ -12,7 +12,7 @@
  * the License.
  */
 
-const logic = require('../../lib/service/businesslogic');
+const logic = require('../../lib/service/functions');
 const should = require('should');
 const testTaskName = 'myTaskName';
 
@@ -22,7 +22,7 @@ function quickRandom() {
 
 function sampleTask(name) {
   return {
-    taskType: 'businessLogic',
+    taskType: 'functions',
     taskName: name,
     method: 'POST',
     endpoint: null,
@@ -269,8 +269,8 @@ describe('business logic', () => {
         should.not.exist(err);
         result.response.statusCode.should.eql(550);
         result.response.body = JSON.parse(result.response.body);
-        result.response.body.error.should.eql('DataLinkRuntimeError');
-        result.response.body.description.should.eql('The Datalink had a runtime error.  See debug message for details');
+        result.response.body.error.should.eql('FlexRuntimeError');
+        result.response.body.description.should.eql('The Flex Service had a runtime error.  See debug message for details');
         result.response.body.debug.should.eql('There was some error in the app!');
         return done();
       });

--- a/test/lib/moduleGenerator.test.js
+++ b/test/lib/moduleGenerator.test.js
@@ -31,7 +31,7 @@ const sampleTaskInfo = {
   authKey: 'abc123',
   requestId: 'ea85600029b04a18a754d57629cff62d',
   serviceObjectName: 'quick',
-  taskType: 'dataLink',
+  taskType: 'data',
   containerMappingId: 'abc:123',
   method: 'POST',
   endpoint: null,


### PR DESCRIPTION
- Rename `kinvey-backend-sdk` to `kinvey-flex-sdk`
- Rename `DataLink` to `FlexData`
- Rename `BusinessLogic` to `FlexFunctions`
- Change readme and examples to refer to the package as `sdk`, the method to generate the service as `service`, and the generated service as `flex`.
